### PR TITLE
Stutter Knockbacks & Projectiles Inheriting Shooter Velocity

### DIFF
--- a/packs/data/gametests/src/main/class.ts
+++ b/packs/data/gametests/src/main/class.ts
@@ -141,6 +141,7 @@ export class CombatManager {
         };
 
         player.__rawDamage = dmg.raw;
+		target.__playerHit = true;
 
         const iframes =
             (timeValid || (dmg.raw > lastAttack.rawDamage && dmg.final > lastAttack.damage)) &&

--- a/packs/data/gametests/src/main/class.ts
+++ b/packs/data/gametests/src/main/class.ts
@@ -141,7 +141,7 @@ export class CombatManager {
         };
 
         player.__rawDamage = dmg.raw;
-		target.__playerHit = true;
+        target.__playerHit = true;
 
         const iframes =
             (timeValid || (dmg.raw > lastAttack.rawDamage && dmg.final > lastAttack.damage)) &&

--- a/packs/data/gametests/src/main/class.ts
+++ b/packs/data/gametests/src/main/class.ts
@@ -1,4 +1,4 @@
-import { world, system, Player } from '@minecraft/server';
+import { world, system, Player, GameMode, EntityDamageCause } from '@minecraft/server';
 import * as mc from '@minecraft/server';
 import { debug, Check, getCooldownTime, selectiveParticle } from './mathAndCalculations.js';
 
@@ -116,7 +116,7 @@ export class CombatManager {
         const shieldBlock = Check.shieldBlock(currentTick, player, target, stats, {
             disable: true,
         });
-        const dmgType = shieldBlock ? 'entityExplosion' : 'entityAttack';
+        const dmgType = shieldBlock ? EntityDamageCause.entityExplosion : EntityDamageCause.entityAttack;
 
         // Knockback calculation
         const applyKnockback = (knockbackLevel, pLoc, tLoc, rot) => {
@@ -145,7 +145,7 @@ export class CombatManager {
 
         const iframes =
             (timeValid || (dmg.raw > lastAttack.rawDamage && dmg.final > lastAttack.damage)) &&
-            !(target instanceof Player && target.getGameMode() == 'creative');
+            !(target instanceof Player && target.getGameMode() == GameMode.creative);
         if (iframes) {
             // Apply sweeping
             sweep = Check.sweep(

--- a/packs/data/gametests/src/main/handler.ts
+++ b/packs/data/gametests/src/main/handler.ts
@@ -583,14 +583,14 @@ world.afterEvents.entityHurt.subscribe(({ damageSource, hurtEntity, damage }) =>
     const player = damageSource.damagingEntity;
     
     if (!player && damageSource.cause !== "override" && damage >= 0) {
-		try {
-			if (!hurtEntity.__playerHit)
-			hurtEntity.applyKnockback({x: 0, z: 0}, hurtEntity.getVelocity().y)
-		} catch (e) {
+        try {
+            if (!hurtEntity.__playerHit)
+                hurtEntity.applyKnockback({x: 0, z: 0}, hurtEntity.getVelocity().y);
+        } catch (e) {
             const debugMode = world.getDynamicProperty("debug_mode");
-		    if (debugMode) debug("Error during knockback: " + e + ", knockback skipped");
+            if (debugMode) debug("Error during knockback: " + e + ", knockback skipped");
         }
-	}
+    }
 
     hurtEntity.__playerHit = false;
     

--- a/packs/data/gametests/src/main/handler.ts
+++ b/packs/data/gametests/src/main/handler.ts
@@ -554,17 +554,17 @@ world.afterEvents.projectileHitEntity.subscribe((event) => {
 });
 
 world.afterEvents.entitySpawn.subscribe(({ cause, entity }) => {
-	if (world.getDynamicProperty('addon_toggle') == false) return;
-	if (!entity?.isValid) return;
+    if (world.getDynamicProperty('addon_toggle') == false) return;
+    if (!entity?.isValid) return;
     
-	const projectileComp = entity?.getComponent('projectile');
-	const owner = projectileComp?.owner;
+    const projectileComp = entity?.getComponent('projectile');
+    const owner = projectileComp?.owner;
     if (!owner) return;
     
-	if (owner instanceof Entity) {
-		const ownerVel = owner.getVelocity();
-		entity.applyImpulse(ownerVel);
-	}
+    if (owner instanceof Entity) {
+        const ownerVel = owner.getVelocity();
+        entity.applyImpulse(ownerVel);
+    }
 });
 
 world.afterEvents.playerSpawn.subscribe(({ player }) => {

--- a/packs/data/gametests/src/main/handler.ts
+++ b/packs/data/gametests/src/main/handler.ts
@@ -8,7 +8,8 @@ import {
     Player,
     CustomCommandStatus,
     CustomCommandSource,
-    EntityDamageCause
+    EntityDamageCause,
+    GameMode
 } from '@minecraft/server';
 import { ModalFormData } from '@minecraft/server-ui';
 import { CombatManager } from './class.js';
@@ -523,7 +524,7 @@ world.afterEvents.playerInteractWithBlock.subscribe(({ player, block }) => {
 world.afterEvents.entityHitBlock.subscribe(({ damagingEntity: player }) => {
     if (!(player instanceof Player)) return;
     if (world.getDynamicProperty('addon_toggle') == false) return;
-    if (player.getGameMode() === 'creative') return;
+    if (player.getGameMode() === GameMode.creative) return;
 
     const status = player.getStatus();
     status.lastShieldTime = system.currentTick;

--- a/packs/data/gametests/src/main/handler.ts
+++ b/packs/data/gametests/src/main/handler.ts
@@ -555,7 +555,7 @@ world.afterEvents.entitySpawn.subscribe(({ cause, entity }) => {
 	if (world.getDynamicProperty('addon_toggle') == false) return;
 	if (!entity?.isValid) return;
     
-	const projectileComp = entity?.getComponent("projectile");
+	const projectileComp = entity?.getComponent('projectile');
 	const owner = projectileComp?.owner;
     if (!owner) return;
     
@@ -596,13 +596,13 @@ world.afterEvents.entityHurt.subscribe(({ damageSource, hurtEntity, damage }) =>
     const currentTick = system.currentTick;
     const player = damageSource.damagingEntity;
     
-    if (!player && damageSource.cause !== "override" && damage >= 0) {
+    if (!player && damageSource.cause !== 'override' && damage >= 0) {
         try {
             if (!hurtEntity.__playerHit)
                 hurtEntity.applyKnockback({x: 0, z: 0}, hurtEntity.getVelocity().y);
         } catch (e) {
-            const debugMode = world.getDynamicProperty("debug_mode");
-            if (debugMode) debug("Error during knockback: " + e + ", knockback skipped");
+            const debugMode = world.getDynamicProperty('debug_mode');
+            if (debugMode) debug('Error during knockback: ' + e + ', knockback skipped');
         }
     }
 

--- a/packs/data/gametests/src/main/handler.ts
+++ b/packs/data/gametests/src/main/handler.ts
@@ -8,6 +8,7 @@ import {
     Player,
     CustomCommandStatus,
     CustomCommandSource,
+    EntityDamageCause
 } from '@minecraft/server';
 import { ModalFormData } from '@minecraft/server-ui';
 import { CombatManager } from './class.js';
@@ -596,7 +597,7 @@ world.afterEvents.entityHurt.subscribe(({ damageSource, hurtEntity, damage }) =>
     const currentTick = system.currentTick;
     const player = damageSource.damagingEntity;
     
-    if (!player && damageSource.cause !== 'override' && damage >= 0) {
+    if (!player && damageSource.cause !== EntityDamageCause.override && damage >= 0) {
         try {
             if (!hurtEntity.__playerHit)
                 hurtEntity.applyKnockback({x: 0, z: 0}, hurtEntity.getVelocity().y);
@@ -609,7 +610,7 @@ world.afterEvents.entityHurt.subscribe(({ damageSource, hurtEntity, damage }) =>
     hurtEntity.__playerHit = false;
     
     if (player instanceof Player) {
-        if (damageSource.cause === 'entityAttack') {
+        if (damageSource.cause === EntityDamageCause.entityAttack) {
             //const { stats } = player.getItemStats();
             //const shieldBlock = Check.shieldBlock(currentTick, player, hurtEntity, stats);
             //if (!shieldBlock)
@@ -619,7 +620,7 @@ world.afterEvents.entityHurt.subscribe(({ damageSource, hurtEntity, damage }) =>
                 time: currentTick,
             };
             healthParticle(hurtEntity, damage);
-        } else if (damageSource.cause === 'maceSmash') {
+        } else if (damageSource.cause === EntityDamageCause.maceSmash) {
             healthParticle(hurtEntity, damage);
         } else {
             hurtEntity.__lastAttack = {

--- a/packs/data/gametests/src/main/handler.ts
+++ b/packs/data/gametests/src/main/handler.ts
@@ -552,6 +552,7 @@ world.afterEvents.projectileHitEntity.subscribe((event) => {
 });
 
 world.afterEvents.entitySpawn.subscribe(({ cause, entity }) => {
+	if (world.getDynamicProperty('addon_toggle') == false) return;
 	if (!entity?.isValid) return;
     
 	const projectileComp = entity?.getComponent("projectile");

--- a/packs/data/gametests/src/main/handler.ts
+++ b/packs/data/gametests/src/main/handler.ts
@@ -581,6 +581,19 @@ world.afterEvents.entityHurt.subscribe(({ damageSource, hurtEntity, damage }) =>
 
     const currentTick = system.currentTick;
     const player = damageSource.damagingEntity;
+    
+    if (!player && damageSource.cause !== "override" && damage >= 0) {
+		try {
+			if (!hurtEntity.__playerHit)
+			hurtEntity.applyKnockback({x: 0, z: 0}, hurtEntity.getVelocity().y)
+		} catch (e) {
+            const debugMode = world.getDynamicProperty("debug_mode");
+		    if (debugMode) debug("Error during knockback: " + e + ", knockback skipped");
+        }
+	}
+
+    hurtEntity.__playerHit = false;
+    
     if (player instanceof Player) {
         if (damageSource.cause === 'entityAttack') {
             //const { stats } = player.getItemStats();

--- a/packs/data/gametests/src/main/handler.ts
+++ b/packs/data/gametests/src/main/handler.ts
@@ -551,6 +551,19 @@ world.afterEvents.projectileHitEntity.subscribe((event) => {
     }
 });
 
+world.afterEvents.entitySpawn.subscribe(({ cause, entity }) => {
+	if (!entity?.isValid) return;
+    
+	const projectileComp = entity?.getComponent("projectile");
+	const owner = projectileComp?.owner;
+    if (!owner) return;
+    
+	if (owner instanceof Entity) {
+		const ownerVel = owner.getVelocity();
+		entity.applyImpulse(ownerVel);
+	}
+});
+
 world.afterEvents.playerSpawn.subscribe(({ player }) => {
     const status = player.getStatus();
     status.lastAttackTime = system.currentTick;

--- a/packs/data/gametests/src/main/mathAndCalculations.ts
+++ b/packs/data/gametests/src/main/mathAndCalculations.ts
@@ -8,6 +8,8 @@ import {
     Player,
     BiomeTypes,
     EquipmentSlot,
+    EntityDamageCause,
+    GameMode
 } from '@minecraft/server';
 import { weaponStats } from './weaponStatsHandler.js';
 import { lambertW0, lambertWm1 } from './lambertw.js';
@@ -505,7 +507,7 @@ export class Check {
 
     // Durability reduction code.
     static durability(player, equippableComp, item, stats) {
-        if (player.getGameMode() === 'creative') return;
+        if (player.getGameMode() === GameMode.creative) return;
         const durabilityComp = item?.getComponent('durability');
         if (!durabilityComp || !stats) return;
 
@@ -587,7 +589,7 @@ export class Check {
                 map,
                 offset
             );
-            if (!(target instanceof Player && target.getGameMode() === 'creative'))
+            if (!(target instanceof Player && target.getGameMode() === GameMode.creative))
                 selectiveSound(player.location, 'critSound', dimension, sound);
         }
         return isValid;
@@ -757,8 +759,8 @@ export class Check {
             let dmgType = this.shieldBlock(currentTick, player, e, stats, {
                 disable: true,
             })
-                ? 'entityExplosion'
-                : 'entityAttack';
+                ? EntityDamageCause.entityExplosion
+                : EntityDamageCause.entityAttack;
 
             let formula = 1 + damage * (level / (level + 1));
 
@@ -816,7 +818,7 @@ export class Check {
         let angle = false;
         let specialValid = true;
 
-        if (target instanceof Player && target.getGameMode() == 'creative') return false;
+        if (target instanceof Player && target.getGameMode() == GameMode.creative) return false;
 
         if (world.getDynamicProperty('shieldBreakSpecial') && player instanceof Player)
             specialValid = Check.specialValid(currentTick, player, stats);


### PR DESCRIPTION
In Java Edition, damages from natural sources cause "stuttering" damages, which knockbacks players by vertical strength of their Y velocity but doing no horizontal knockbacks.

Also, one of the Combat Update's feature is projectile inheriting player's velocity. For example, throwing a snowball downwards while falling will give snowballs more momentum.