### PR TITLE
Change bow hitsound to use UI category in sound definition

### DIFF
--- a/packs/RP/sounds/sound_definitions.json
+++ b/packs/RP/sounds/sound_definitions.json
@@ -164,6 +164,15 @@
                     "volume": 0
                 }
             ]
+        },
+        "game.player.bow.ding": {
+            "category": "ui",
+            "sounds": [
+                {
+                    "name": "sounds/random/orb",
+                    "volume": 0.5
+                }
+            ]
         }
     }
 }

--- a/packs/data/gametests/src/main/handler.ts
+++ b/packs/data/gametests/src/main/handler.ts
@@ -547,7 +547,7 @@ world.afterEvents.projectileHitEntity.subscribe((event) => {
         player !== target &&
         projectile.typeId === 'minecraft:arrow'
     ) {
-        player.playSound('random.orb', { pitch: 0.5 });
+        player.playSound('game.player.bow.ding', { pitch: 0.5 });
     }
 });
 


### PR DESCRIPTION
Currently, bow hitsounds use 'random.orb' sound definition directly. This causes an issue where sounds get inconsistent volume. Adding a separate sound definition with UI category fixes that, and keeps the volume same regardless of distance from where the sound plays.