### PR TITLE
Add Saturation Healing

### DIFF
--- a/packs/BP/manifest.json
+++ b/packs/BP/manifest.json
@@ -5,7 +5,7 @@
         "description": "pack.description",
         "uuid": "29cfdcbb-2333-4334-89ec-1879e98c0f28",
         "version": [2, 0, 0],
-        "min_engine_version": [1, 21, 80]
+        "min_engine_version": [1, 21, 90]
     },
     "modules": [
         {

--- a/packs/RP/manifest.json
+++ b/packs/RP/manifest.json
@@ -6,7 +6,7 @@
         "uuid": "2e95c672-8edb-4706-9ef2-e97226bdffde",
         "pack_scope": "world",
         "version": [2, 0, 0],
-        "min_engine_version": [1, 21, 80]
+        "min_engine_version": [1, 21, 90]
     },
     "modules": [
         {

--- a/packs/RP/texts/en_US.lang
+++ b/packs/RP/texts/en_US.lang
@@ -14,7 +14,7 @@ sweepnslash.toggledebugmode=Toggle Debug Mode
 sweepnslash.toggledebugmode.tooltip=Debug mode toggle for developers and creators. Prints various informations in Content Log, and enables DPS tester ('sns:testdamage' script event).
 
 ## Server Toggles
-sweepnslash.operatortoggleheader=Server Toggles
+sweepnslash.servertoggleheader=Server Toggles
 sweepnslash.shieldbreakspecial=Require Charged Axes to Break Shields
 sweepnslash.shieldbreakspecial.tooltip=If enabled, axes disable shields only if the attacker's cooldown charge is above 84.8%%.
 sweepnslash.saturationhealing=Saturation Healing

--- a/packs/RP/texts/en_US.lang
+++ b/packs/RP/texts/en_US.lang
@@ -4,40 +4,44 @@ pack.description=Converts Bedrock Edition's combat into Java Edition's 1.9+ comb
 attribute.name.generic.attackDamage=§r
 
 sweepnslash.tipmessage=§fType §e%s §fto open §3Sweep §f'N §6Slash §fconfiguration menu
+sweepnslash.currentversion=Current version:§e %s
+
+## Advanced Operator Toggles
+sweepnslash.operatortoggleheader=Advanced Operator Toggles
 sweepnslash.configmenutitle=Sweep 'N Slash Configuration
 sweepnslash.toggleaddon=Toggle Add-On
-sweepnslash.shieldbreakspecial=Require Charged Axes to Break Shields
 sweepnslash.toggledebugmode=Toggle Debug Mode
+sweepnslash.toggledebugmode.tooltip=Debug mode toggle for developers and creators. Prints various informations in Content Log, and enables DPS tester ('sns:testdamage' script event).
+
+## Server Toggles
+sweepnslash.operatortoggleheader=Server Toggles
+sweepnslash.shieldbreakspecial=Require Charged Axes to Break Shields
+sweepnslash.shieldbreakspecial.tooltip=If enabled, axes disable shields only if the attacker's cooldown charge is above 84.8%%.
+sweepnslash.saturationhealing=Saturation Healing
+sweepnslash.saturationhealing.tooltip=If enabled, saturation will be used more rapidly for healing. This will force Natural Regeneration gamerule off.
+
+## General Toggles
+sweepnslash.generaltoggleheader=General Toggles
 sweepnslash.excludepetfromsweep=Ignore Tamed Pets On Sweep
+sweepnslash.excludepetfromsweep.tooltip=If enabled, sweep attacks will not damage tamed pets.
 sweepnslash.tipmessagetoggle=Tip Message Upon Joining
+
+## Personal Settings
+sweepnslash.personaltoggleheader=Personal Settings
 sweepnslash.indicatorstyle=Attack Indicator
+sweepnslash.indicatorstyle.tooltip=Changes Attack Indicator UI. If you're having issues with the addon's UI, try using Geyser.
 sweepnslash.crosshair=Crosshair
 sweepnslash.hotbar=Hotbar
 sweepnslash.geyser=Geyser
 sweepnslash.none=None
+sweepnslash.bowhitsound=Bow Hit Sound
 sweepnslash.sweepparticles=Sweep Particles
 sweepnslash.enchantedhitparticles=Enchanted Hit Particles
 sweepnslash.damageindicatorparticles=Damage Indicator Particles
 sweepnslash.critparticles=Critical Hit Particles
 sweepnslash.critsounds=Critical Hit Sounds
 sweepnslash.sweepRGBtitle=Sweep RGB Color
-sweepnslash.nan=§cNaN(Not a Number) value has been registered in sweep RGB color. Falling back to 0.
 sweepnslash.saveconfig=Save
+
 sweepnslash.canceled=§cConfiguration canceled.
 sweepnslash.saved=§aConfiguration saved.
-sweepnslash.configopened=Configuration menu has been opened outside the chat screen.
-sweepnslash.bowhitsound=Bow Hit Sound
-sweepnslash.operatortoggleheader=Advanced Operator Toggles
-sweepnslash.generaltoggleheader=General Toggles
-sweepnslash.personaltoggleheader=Personal Settings
-sweepnslash.currentversion=Current version:§e %s
-
-sweepnslash.shieldbreakspecial.tooltip=If enabled, axes disable shields only if the attacker's cooldown charge is above 84.8%%.
-sweepnslash.toggledebugmode.tooltip=Debug mode toggle for developers and creators. Prints various informations in Content Log, and enables DPS tester ('sns:testdamage' script event).
-sweepnslash.excludepetfromsweep.tooltip=If enabled, sweep attacks will not damage tamed pets.
-sweepnslash.indicatorstyle.tooltip=Changes Attack Indicator UI. If you're having issues with the addon's UI, try using Geyser.
-
-
-
-
-

--- a/packs/RP/texts/en_US.lang
+++ b/packs/RP/texts/en_US.lang
@@ -6,9 +6,10 @@ attribute.name.generic.attackDamage=§r
 sweepnslash.tipmessage=§fType §e%s §fto open §3Sweep §f'N §6Slash §fconfiguration menu
 sweepnslash.currentversion=Current version:§e %s
 
+sweepnslash.configmenutitle=Sweep 'N Slash Configuration
+
 ## Advanced Operator Toggles
 sweepnslash.operatortoggleheader=Advanced Operator Toggles
-sweepnslash.configmenutitle=Sweep 'N Slash Configuration
 sweepnslash.toggleaddon=Toggle Add-On
 sweepnslash.toggledebugmode=Toggle Debug Mode
 sweepnslash.toggledebugmode.tooltip=Debug mode toggle for developers and creators. Prints various informations in Content Log, and enables DPS tester ('sns:testdamage' script event).

--- a/packs/RP/texts/ko_KR.lang
+++ b/packs/RP/texts/ko_KR.lang
@@ -19,7 +19,7 @@ sweepnslash.servertoggleheader=서버 설정
 sweepnslash.shieldbreakspecial=도끼 대 방패에 쿨다운 적용
 sweepnslash.shieldbreakspecial.tooltip=도끼로 방패를 공격할 때 공격 쿨다운이 84.8%% 이하로 떨어진 상태가 아닐 경우에만 방패를 무력화하도록 합니다.
 sweepnslash.saturationhealing=포만감 회복
-sweepnslash.saturationhealing.tooltip=포만감을 사용하여 체력을 빠르게 회복합니다. 자연 재생 게임 규칙이 자동으로 비활성화됩니다.
+sweepnslash.saturationhealing.tooltip=포만감을 사용하여 체력을 빠르게 회복합니다. 자연 재생 게임 규칙이 강제로 비활성화됩니다.
 
 ## General Toggles
 sweepnslash.generaltoggleheader=일반 설정

--- a/packs/RP/texts/ko_KR.lang
+++ b/packs/RP/texts/ko_KR.lang
@@ -6,9 +6,10 @@ attribute.name.generic.attackDamage=§r
 sweepnslash.tipmessage=§e%s §f명령어를 입력하여 §3Sweep §f'N §6Slash §f설정 화면 열기
 sweepnslash.currentversion=현재 버전:§e %s
 
+sweepnslash.configmenutitle=Sweep 'N Slash 설정
+
 ## Advanced Operator Toggles
 sweepnslash.operatortoggleheader=고급 애드온 설정
-sweepnslash.configmenutitle=Sweep 'N Slash 설정
 sweepnslash.toggleaddon=애드온 활성화
 sweepnslash.toggledebugmode=디버그 모드 활성화
 sweepnslash.toggledebugmode.tooltip=개발자를 위한 디버그 모드입니다. 콘텐츠 로그에 여러 정보를 출력하며, DPS 실험 기능을 활성화합니다. ('sns:testdamage' 스크립트 이벤트)

--- a/packs/RP/texts/ko_KR.lang
+++ b/packs/RP/texts/ko_KR.lang
@@ -4,35 +4,44 @@ pack.description=자바 에디션 전투를 베드락 에디션에서 경험해�
 attribute.name.generic.attackDamage=§r
 
 sweepnslash.tipmessage=§e%s §f명령어를 입력하여 §3Sweep §f'N §6Slash §f설정 화면 열기
+sweepnslash.currentversion=현재 버전:§e %s
+
+## Advanced Operator Toggles
+sweepnslash.operatortoggleheader=고급 애드온 설정
 sweepnslash.configmenutitle=Sweep 'N Slash 설정
 sweepnslash.toggleaddon=애드온 활성화
-sweepnslash.shieldbreakspecial=도끼 대 방패에 쿨다운 적용
 sweepnslash.toggledebugmode=디버그 모드 활성화
+sweepnslash.toggledebugmode.tooltip=개발자를 위한 디버그 모드입니다. 콘텐츠 로그에 여러 정보를 출력하며, DPS 실험 기능을 활성화합니다. ('sns:testdamage' 스크립트 이벤트)
+
+## Server Toggles
+sweepnslash.servertoggleheader=서버 설정
+sweepnslash.shieldbreakspecial=도끼 대 방패에 쿨다운 적용
+sweepnslash.shieldbreakspecial.tooltip=도끼로 방패를 공격할 때 공격 쿨다운이 84.8%% 이하로 떨어진 상태가 아닐 경우에만 방패를 무력화하도록 합니다.
+sweepnslash.saturationhealing=포만감 회복
+sweepnslash.saturationhealing.tooltip=포만감을 사용하여 체력을 빠르게 회복합니다. 자연 재생 게임 규칙이 자동으로 비활성화됩니다.
+
+## General Toggles
+sweepnslash.generaltoggleheader=일반 설정
 sweepnslash.excludepetfromsweep=휩쓸기 공격에서 길들여진 몹 무시
+sweepnslash.excludepetfromsweep.tooltip=길들여진 몹이 휩쓸기 공격에 피해를 받지 않도록 합니다.
 sweepnslash.tipmessagetoggle=세계 입장 시 팁 메세지 표시
+
+## Personal Settings
+sweepnslash.personaltoggleheader=개인 설정
 sweepnslash.indicatorstyle=공격 지표
+sweepnslash.indicatorstyle.tooltip=공격 지표의 모양을 변경합니다. UI에 문제가 생길 경우 Geyser를 시도해보세요.
 sweepnslash.crosshair=십자선
 sweepnslash.hotbar=단축 바
 sweepnslash.geyser=Geyser
 sweepnslash.none=비활성화
+sweepnslash.bowhitsound=화살 명중 효과음
 sweepnslash.sweepparticles=휩쓸기 공격 입자
 sweepnslash.enchantedhitparticles=마법 부여 공격 입자
 sweepnslash.damageindicatorparticles=피해 입자
 sweepnslash.critparticles=치명타 공격 입자
 sweepnslash.critsounds=치명타 공격 효과음
 sweepnslash.sweepRGBtitle=휩쓸기 공격 입자 색상
-sweepnslash.nan=§cNaN(Not a Number)가 휩쓸기 공격 입자 색상에 입력되었습니다. 0으로 설정합니다.
 sweepnslash.saveconfig=저장
+
 sweepnslash.canceled=§c설정이 취소되었습니다.
 sweepnslash.saved=§a설정이 저장되었습니다.
-sweepnslash.configopened=채팅 화면 외부에 설정 메뉴가 열렸습니다.
-sweepnslash.bowhitsound=화살 명중 효과음
-sweepnslash.operatortoggleheader=고급 애드온 설정
-sweepnslash.generaltoggleheader=일반 설정
-sweepnslash.personaltoggleheader=개인 설정
-sweepnslash.currentversion=현재 버전:§e %s
-
-sweepnslash.shieldbreakspecial.tooltip=도끼로 방패를 공격할 때 공격 쿨다운이 84.8%% 이하로 떨어진 상태가 아닐 경우에만 방패를 무력화하도록 합니다.
-sweepnslash.toggledebugmode.tooltip=개발자를 위한 디버그 모드입니다. 콘텐츠 로그에 여러 정보를 출력하며, DPS 실험 기능을 활성화합니다. ('sns:testdamage' 스크립트 이벤트)
-sweepnslash.excludepetfromsweep.tooltip=길들여진 몹이 휩쓸기 공격에 피해를 받지 않도록 합니다.
-sweepnslash.indicatorstyle.tooltip=공격 지표의 모양을 변경합니다. UI에 문제가 생길 경우 Geyser를 시도해보세요.

--- a/packs/RP/texts/ko_KR.lang
+++ b/packs/RP/texts/ko_KR.lang
@@ -12,14 +12,14 @@ sweepnslash.configmenutitle=Sweep 'N Slash 설정
 sweepnslash.operatortoggleheader=고급 애드온 설정
 sweepnslash.toggleaddon=애드온 활성화
 sweepnslash.toggledebugmode=디버그 모드 활성화
-sweepnslash.toggledebugmode.tooltip=개발자를 위한 디버그 모드입니다. 콘텐츠 로그에 여러 정보를 출력하며, DPS 실험 기능을 활성화합니다. ('sns:testdamage' 스크립트 이벤트)
+sweepnslash.toggledebugmode.tooltip=개발자를 위한 디버그 모드입니다. 콘텐츠 로그에 개발에 필요한 여러 정보를 출력하며, DPS 실험 기능을 활성화합니다. ('sns:testdamage' 스크립트 이벤트)
 
 ## Server Toggles
 sweepnslash.servertoggleheader=서버 설정
 sweepnslash.shieldbreakspecial=도끼 대 방패에 쿨다운 적용
-sweepnslash.shieldbreakspecial.tooltip=도끼로 방패를 공격할 때 공격 쿨다운이 84.8%% 이하로 떨어진 상태가 아닐 경우에만 방패를 무력화하도록 합니다.
+sweepnslash.shieldbreakspecial.tooltip=도끼를 든 채로 방패를 공격할 때 공격 쿨다운이 84.8%% 이상인 경우에만 방패를 무력화하도록 합니다.
 sweepnslash.saturationhealing=포만감 회복
-sweepnslash.saturationhealing.tooltip=포만감을 사용하여 체력을 빠르게 회복합니다. 자연 재생 게임 규칙이 강제로 비활성화됩니다.
+sweepnslash.saturationhealing.tooltip=포만감을 사용하여 체력을 빠르게 회복합니다. 활성화 시 '자연 재생' 월드 옵션이 강제로 비활성화됩니다.
 
 ## General Toggles
 sweepnslash.generaltoggleheader=일반 설정

--- a/packs/RP/texts/ro_RO.lang
+++ b/packs/RP/texts/ro_RO.lang
@@ -4,40 +4,45 @@ pack.description=Aduce sistemul de luptă al Ediției Java 1.9+ în Ediția Bedr
 attribute.name.generic.attackDamage=§r
 
 sweepnslash.tipmessage=§fScrie §e%s §fpentru a deschide meniul de configurare al §3Sweep §f'N §6Slash §f
+sweepnslash.currentversion=Versiune curentă:§e %s
+
 sweepnslash.configmenutitle=Configurare Sweep 'N Slash
+
+## Advanced Operator Toggles
+sweepnslash.operatortoggleheader=Opțiuni avansate de operator
 sweepnslash.toggleaddon=Activează Add-On
-sweepnslash.shieldbreakspecial=Necesită topoare încărcate pentru a sparge scuturile
 sweepnslash.toggledebugmode=Activează modul de depanare
+sweepnslash.toggledebugmode.tooltip=Opțiune mod depanare pentru dezvoltatori și creatori. Scoate diverse informații în Jurnalul de Conținut, și activează testerul DPS (evenimentul de sctipt „sns:testdamage”).
+
+## Server Toggles
+sweepnslash.servertoggleheader=Opțiuni avansate de server
+sweepnslash.shieldbreakspecial=Necesită topoare încărcate pentru a sparge scuturile
+sweepnslash.shieldbreakspecial.tooltip=Dacă este activată, topoarele dezactivează scuturi doar dacă încărcarea cooldown-ului atacatorului este peste 84.8%.
+sweepnslash.saturationhealing=Regenerare bazată pe saturație
+sweepnslash.saturationhealing.tooltip=Dacă este activată, saturația va fi consumată mai rapid pentru regenerare. Acest lucru va opti forțat regula de joc „Regenerare naturală”.
+
+## General Toggles
+sweepnslash.generaltoggleheader=Opțiuni generale
 sweepnslash.excludepetfromsweep=Ignoră animalele îmblânzite la sfâșiere
+sweepnslash.excludepetfromsweep.tooltip=Dacă este activată, atacurile de sfâșiere nu vor lovi animalele îmblânzite.
 sweepnslash.tipmessagetoggle=Arată mesaje sfat la intrarea în lume
+
+## Personal Settings
+sweepnslash.personaltoggleheader=Setări personale
 sweepnslash.indicatorstyle=Indicator atac
+sweepnslash.indicatorstyle.tooltip=Schimbă interfața Indicatorului de atac. Dacă aveți probleme cu interfața addon-ului, încercați să folosiți Gheizer.
 sweepnslash.crosshair=Reticul
 sweepnslash.hotbar=Bară de acțiune
 sweepnslash.geyser=Geyser
 sweepnslash.none=Fără
+sweepnslash.bowhitsound=Sunet lovire arc
 sweepnslash.sweepparticles=Particule sfâșiere
 sweepnslash.enchantedhitparticles=Particule lovitură fermecată
 sweepnslash.damageindicatorparticles=Particyle indicator lovire
 sweepnslash.critparticles=Partivule lovitură critică
 sweepnslash.critsounds=Sunete lovitură critică
 sweepnslash.sweepRGBtitle=Culoare RGB sfâșiere
-sweepnslash.nan=§cValoare NaN(Nu e Număr) a fost înregistrată la culoare RGB sfâșiere. Se revine la 0.
 sweepnslash.saveconfig=Salvare
+
 sweepnslash.canceled=§cConfigurație anulată.
 sweepnslash.saved=§aConfigurație salvată.
-sweepnslash.configopened=Meniu configurare deschis în afara ecranului de chat.
-sweepnslash.bowhitsound=Sunet lovire arc
-sweepnslash.operatortoggleheader=Opțiuni avansate de operator
-sweepnslash.generaltoggleheader=Opțiuni generale
-sweepnslash.personaltoggleheader=Setări personale
-sweepnslash.currentversion=Versiune curentă:§e %s
-
-sweepnslash.shieldbreakspecial.tooltip=Dacă este activată, topoarele dezactivează scuturi doar dacă încărcarea cooldown-ului atacatorului este peste 84.8%.
-sweepnslash.toggledebugmode.tooltip=Opțiune mod depanare pentru dezvoltatori și creatori. Scoate diverse informații în Jurnalul de Conținut, și activează testerul DPS (evenimentul de sctipt „sns:testdamage”).
-sweepnslash.excludepetfromsweep.tooltip=Dacă este activată, atacurile de sfâșiere nu vor lovi animalele îmblânzite.
-sweepnslash.indicatorstyle.tooltip=Schimbă interfața Indicatorului de atac. Dacă aveți probleme cu interfața addon-ului, încercați să folosiți Gheizer.
-
-
-
-
-

--- a/packs/RP/texts/zh_CN.lang
+++ b/packs/RP/texts/zh_CN.lang
@@ -4,40 +4,45 @@ pack.description=将基岩版的战斗机制改为Java版1.9+的战斗机制
 attribute.name.generic.attackDamage=§r
 
 sweepnslash.tipmessage=§f输入 §e%s §f打开§3Sweep §f'N §6Slash §f设置菜单
+sweepnslash.currentversion=当前版本:§e %s
+
 sweepnslash.configmenutitle=Sweep 'N Slash设置菜单
+
+## Advanced Operator Toggles
+sweepnslash.operatortoggleheader=高级开发者设置
 sweepnslash.toggleaddon=切换为Add-On模式
-sweepnslash.shieldbreakspecial=需蓄力斧破盾
 sweepnslash.toggledebugmode=切换为调试模式
+sweepnslash.toggledebugmode.tooltip=给开发者准备的调试模式。所有信息将显示在内容日志中，并且启用DPS测试（'sns:testdamage'的脚本信息）
+
+## Server Toggles
+sweepnslash.servertoggleheader=服务器设置
+sweepnslash.shieldbreakspecial=需蓄力斧破盾
+sweepnslash.shieldbreakspecial.tooltip=启用后，只有在攻击冷却完成度大于84.8%时斧头可以破盾
+sweepnslash.saturationhealing=饱和度用于回血
+sweepnslash.saturationhealing.tooltip=启用后，饱和度会被更快消耗用于回血。该选项会自动禁用"自然生命恢复"选项
+
+## General Toggles
+sweepnslash.generaltoggleheader=通用
 sweepnslash.excludepetfromsweep=横扫攻击时不误伤宠物
+sweepnslash.excludepetfromsweep.tooltip=启用后，横扫攻击将不会对宠物造成伤害
 sweepnslash.tipmessagetoggle=进入游戏时加载提示信息
+
+## Personal Settings
+sweepnslash.personaltoggleheader=自定义
 sweepnslash.indicatorstyle=攻击指示器
+sweepnslash.indicatorstyle.tooltip=改变攻击显示器的UI。如果使用该模组时UI有问题的话，建议用Geyser模式
 sweepnslash.crosshair=十字准星下
 sweepnslash.hotbar=快捷栏旁
 sweepnslash.geyser=Geyser模式
 sweepnslash.none=无
+sweepnslash.bowhitsound=弓箭命中音效
 sweepnslash.sweepparticles=横扫粒子
 sweepnslash.enchantedhitparticles=附魔武器攻击粒子
 sweepnslash.damageindicatorparticles=伤害显示粒子
 sweepnslash.critparticles=暴击粒子
 sweepnslash.critsounds=暴击音效
 sweepnslash.sweepRGBtitle=横扫粒子颜色(RGB)
-sweepnslash.nan=§cNaN(Not a Number) value has been registered in sweep RGB color. Falling back to 0.
 sweepnslash.saveconfig=保存
+
 sweepnslash.canceled=§c已取消保存
 sweepnslash.saved=§a已保存设置
-sweepnslash.configopened=设置菜单已在聊天框之外打开
-sweepnslash.bowhitsound=弓箭命中音效
-sweepnslash.operatortoggleheader=Advanced Operator Toggles
-sweepnslash.generaltoggleheader=通用
-sweepnslash.personaltoggleheader=自定义
-sweepnslash.currentversion=当前版本:§e %s
-
-sweepnslash.shieldbreakspecial.tooltip=启用后，只有在攻击冷却完成度大于84.8%时斧头可以破盾
-sweepnslash.toggledebugmode.tooltip=给开发者准备的调试模式。所有信息将显示在内容日志中，并且启用DPS测试（'sns:testdamage'的脚本信息）
-sweepnslash.excludepetfromsweep.tooltip=启用后，横扫攻击将不会对宠物造成伤害
-sweepnslash.indicatorstyle.tooltip=改变攻击显示器的UI。如果使用该模组时UI有问题的话，建议用Geyser模式
-
-
-
-
-

--- a/packs/data/gametests/src/main/class.ts
+++ b/packs/data/gametests/src/main/class.ts
@@ -192,9 +192,11 @@ export class CombatManager {
                 status.mace === false &&
                 !inanimate &&
                 dmg.final > 0 &&
-                !beforeEffect?.cancelDurability
             ) {
-                Check.durability(player, equippableComp, item, stats);
+                if (player.getGameMode() !== GameMode.Creative) {
+					player.setExhaustion(player.getExhaustion() + 0.1);
+				}
+                if (!beforeEffect?.cancelDurability) Check.durability(player, equippableComp, item, stats);
             }
 
             // Apply knockback

--- a/packs/data/gametests/src/main/class.ts
+++ b/packs/data/gametests/src/main/class.ts
@@ -194,8 +194,8 @@ export class CombatManager {
                 dmg.final > 0 &&
             ) {
                 if (player.getGameMode() !== GameMode.Creative) {
-					player.setExhaustion(player.getExhaustion() + 0.1);
-				}
+                    player.setExhaustion(player.getExhaustion() + 0.1);
+                }
                 if (!beforeEffect?.cancelDurability) Check.durability(player, equippableComp, item, stats);
             }
 

--- a/packs/data/gametests/src/main/class.ts
+++ b/packs/data/gametests/src/main/class.ts
@@ -191,7 +191,7 @@ export class CombatManager {
             if (
                 status.mace === false &&
                 !inanimate &&
-                dmg.final > 0 &&
+                dmg.final > 0
             ) {
                 if (player.getGameMode() !== GameMode.Creative) {
                     player.setExhaustion(player.getExhaustion() + 0.1);

--- a/packs/data/gametests/src/main/handler.ts
+++ b/packs/data/gametests/src/main/handler.ts
@@ -391,50 +391,50 @@ system.runInterval(() => {
         // Saturation healing
         
         const health = player.getComponent("health");
-		const hunger = player.getHunger();
-		const saturation = player.getSaturation();
-		const exhaustion = player.getExhaustion();
+        const hunger = player.getHunger();
+        const saturation = player.getSaturation();
+        const exhaustion = player.getExhaustion();
 
-		const saturationEffect = player.getEffect("saturation");
-		if (saturationEffect?.isValid && health.currentValue > 0) {
-			const saturationComp = player.getComponent("player.saturation");
-			player.setSaturation(clampNumber(saturation + ((saturationEffect.amplifier + 1) * 2), saturationComp?.effectiveMin, saturationComp?.effectiveMax));
-		}
+        const saturationEffect = player.getEffect("saturation");
+        if (saturationEffect?.isValid && health.currentValue > 0) {
+            const saturationComp = player.getComponent("player.saturation");
+            player.setSaturation(clampNumber(saturation + ((saturationEffect.amplifier + 1) * 2), saturationComp?.effectiveMin, saturationComp?.effectiveMax));
+        }
 
-		const canHeal =
-			hunger >= 18 &&
-			health.currentValue > 0 &&
-			health.currentValue < health.effectiveMax &&
-			player.getGameMode() !== "Creative";
-			
-		if (canHeal) {
-			status.foodTickTimer += 1;
+        const canHeal =
+            hunger >= 18 &&
+            health.currentValue > 0 &&
+            health.currentValue < health.effectiveMax &&
+            player.getGameMode() !== "Creative";
+            
+        if (canHeal) {
+            status.foodTickTimer += 1;
 
-			const usingSaturation = saturation > 0;
-			const foodTick = usingSaturation ? 10 : 80;
+            const usingSaturation = saturation > 0;
+            const foodTick = usingSaturation ? 10 : 80;
 
-			if (status.foodTickTimer >= foodTick) {
-				let healAmount = 0;
-				let exhaustionToAdd = 0;
+            if (status.foodTickTimer >= foodTick) {
+                let healAmount = 0;
+                let exhaustionToAdd = 0;
 
-				if (usingSaturation) {
-					healAmount = Math.min(1.0, saturation / 6.0);
-					exhaustionToAdd = healAmount * 6.0;
-				} else {
-					healAmount = 1.0;
-					exhaustionToAdd = 6.0;
-				}
+                if (usingSaturation) {
+                    healAmount = Math.min(1.0, saturation / 6.0);
+                    exhaustionToAdd = healAmount * 6.0;
+                } else {
+                    healAmount = 1.0;
+                    exhaustionToAdd = 6.0;
+                }
 
-				// Apply healing and exhaustion
-				player.setExhaustion(exhaustion + exhaustionToAdd);
-				health.setCurrentValue(
-					clampNumber(health.currentValue + healAmount, health.effectiveMin, health.effectiveMax)
-				);
-				status.foodTickTimer = 0;
-			}
-		} else {
-			status.foodTickTimer = 0;
-		}
+                // Apply healing and exhaustion
+                player.setExhaustion(exhaustion + exhaustionToAdd);
+                health.setCurrentValue(
+                    clampNumber(health.currentValue + healAmount, health.effectiveMin, health.effectiveMax)
+                );
+                status.foodTickTimer = 0;
+            }
+        } else {
+            status.foodTickTimer = 0;
+        }
 
         // For UI
         const maxCD = getCooldownTime(player, stats?.attackSpeed).ticks;

--- a/packs/data/gametests/src/main/handler.ts
+++ b/packs/data/gametests/src/main/handler.ts
@@ -120,7 +120,7 @@ function configFormOpener({ sourceEntity: player, sourceType }) {
 
 function configForm(player) {
     const tag = player.hasTag('sweepnslash.config');
-    const op = player.playerPermissionLevel = PlayerPermissionLevel.Operator;
+    const op = player.playerPermissionLevel == PlayerPermissionLevel.Operator;
     let formValuesPush = 0;
 
     let form = new ModalFormData().title({

--- a/packs/data/gametests/src/main/handler.ts
+++ b/packs/data/gametests/src/main/handler.ts
@@ -410,7 +410,7 @@ system.runInterval(() => {
         if (canHeal) {
             status.foodTickTimer += 1;
 
-            const usingSaturation = saturation > 0;
+            const usingSaturation = saturation > 0 && hunger >= 20;
             const foodTick = usingSaturation ? 10 : 80;
 
             if (status.foodTickTimer >= foodTick) {

--- a/packs/data/gametests/src/main/handler.ts
+++ b/packs/data/gametests/src/main/handler.ts
@@ -388,6 +388,54 @@ system.runInterval(() => {
             player.triggerEvent('sweepnslash:mace');
         }
 
+        // Saturation healing
+        
+        const health = player.getComponent("health");
+		const hunger = player.getHunger();
+		const saturation = player.getSaturation();
+		const exhaustion = player.getExhaustion();
+
+		const saturationEffect = player.getEffect("saturation");
+		if (saturationEffect?.isValid && health.currentValue > 0) {
+			const saturationComp = player.getComponent("player.saturation");
+			player.setSaturation(clampNumber(saturation + ((saturationEffect.amplifier + 1) * 2), saturationComp?.effectiveMin, saturationComp?.effectiveMax));
+		}
+
+		const canHeal =
+			hunger >= 18 &&
+			health.currentValue > 0 &&
+			health.currentValue < health.effectiveMax &&
+			player.getGameMode() !== "Creative";
+			
+		if (canHeal) {
+			status.foodTickTimer += 1;
+
+			const usingSaturation = saturation > 0;
+			const foodTick = usingSaturation ? 10 : 80;
+
+			if (status.foodTickTimer >= foodTick) {
+				let healAmount = 0;
+				let exhaustionToAdd = 0;
+
+				if (usingSaturation) {
+					healAmount = Math.min(1.0, saturation / 6.0);
+					exhaustionToAdd = healAmount * 6.0;
+				} else {
+					healAmount = 1.0;
+					exhaustionToAdd = 6.0;
+				}
+
+				// Apply healing and exhaustion
+				player.setExhaustion(exhaustion + exhaustionToAdd);
+				health.setCurrentValue(
+					clampNumber(health.currentValue + healAmount, health.effectiveMin, health.effectiveMax)
+				);
+				status.foodTickTimer = 0;
+			}
+		} else {
+			status.foodTickTimer = 0;
+		}
+
         // For UI
         const maxCD = getCooldownTime(player, stats?.attackSpeed).ticks;
         status.cooldown = Math.max(0, status.lastAttackTime + maxCD - currentTick);

--- a/packs/data/gametests/src/main/handler.ts
+++ b/packs/data/gametests/src/main/handler.ts
@@ -405,7 +405,7 @@ system.runInterval(() => {
             hunger >= 18 &&
             health.currentValue > 0 &&
             health.currentValue < health.effectiveMax &&
-            player.getGameMode() !== "Creative";
+            player.getGameMode() !== GameMode.Creative;
             
         if (canHeal) {
             status.foodTickTimer += 1;

--- a/packs/data/gametests/src/main/handler.ts
+++ b/packs/data/gametests/src/main/handler.ts
@@ -10,7 +10,8 @@ import {
     CustomCommandStatus,
     CustomCommandSource,
     EntityDamageCause,
-    GameMode
+    GameMode,
+    PlayerPermissionLevel
 } from '@minecraft/server';
 import { ModalFormData } from '@minecraft/server-ui';
 import { CombatManager } from './class.js';
@@ -50,6 +51,10 @@ world.afterEvents.worldLoad.subscribe(() => {
 
     if (world.getDynamicProperty('shieldBreakSpecial') == undefined) {
         world.setDynamicProperty('shieldBreakSpecial', false);
+    }
+
+    if (world.getDynamicProperty('saturationHealing') == undefined) {
+        world.setDynamicProperty('saturationHealing', true);
     }
 });
 
@@ -114,7 +119,8 @@ function configFormOpener({ sourceEntity: player, sourceType }) {
 }
 
 function configForm(player) {
-    const op = player.hasTag('sweepnslash.config');
+    const tag = player.hasTag('sweepnslash.config');
+    const op = player.playerPermissionLevel = PlayerPermissionLevel.Operator;
     let formValuesPush = 0;
 
     let form = new ModalFormData().title({
@@ -126,13 +132,25 @@ function configForm(player) {
         return object.getDynamicProperty(id);
     }
 
-    if (op == true) {
+    if (tag == true) {
         form.label({ translate: 'sweepnslash.operatortoggleheader' });
         if (!world.isHardcore)
-            form.toggle(
-                { translate: 'sweepnslash.toggleaddon' },
-                { defaultValue: dp(world, { id: 'addon_toggle' }) }
-            );
+        form.toggle(
+            { translate: 'sweepnslash.toggleaddon' },
+            { defaultValue: dp(world, { id: 'addon_toggle' }) }
+        );
+        form.toggle(
+            { translate: 'sweepnslash.toggledebugmode' },
+            {
+                defaultValue: dp(world, { id: 'debug_mode' }),
+                tooltip: { translate: 'sweepnslash.toggledebugmode.tooltip' },
+            }
+        );
+        form.divider();
+    }
+
+    if (op == true) {
+        form.label({ translate: 'sweepnslash.servertoggleheader' });
         form.toggle(
             { translate: 'sweepnslash.shieldbreakspecial' },
             {
@@ -141,10 +159,10 @@ function configForm(player) {
             }
         );
         form.toggle(
-            { translate: 'sweepnslash.toggledebugmode' },
+            { translate: 'sweepnslash.saturationhealing' },
             {
-                defaultValue: dp(world, { id: 'debug_mode' }),
-                tooltip: { translate: 'sweepnslash.toggledebugmode.tooltip' },
+                defaultValue: dp(world, { id: 'saturationHealing' }),
+                tooltip: { translate: 'sweepnslash.saturationhealing.tooltip' },
             }
         );
         form.divider();
@@ -259,10 +277,11 @@ function configForm(player) {
             {
                 object: world,
                 dynamicProperty: 'addon_toggle',
-                condition: op && !world.isHardcore,
+                condition: tag && !world.isHardcore,
             },
+            { object: world, dynamicProperty: 'debug_mode', condition: tag },
             { object: world, dynamicProperty: 'shieldBreakSpecial', condition: op },
-            { object: world, dynamicProperty: 'debug_mode', condition: op },
+            { object: world, dynamicProperty: 'saturationHealing', condition: op },
             { object: player, dynamicProperty: 'excludePetFromSweep' },
             { object: player, dynamicProperty: 'tipMessage' },
             { object: player, dynamicProperty: 'cooldownStyle' },
@@ -309,6 +328,7 @@ system.beforeEvents.startup.subscribe((init) => {
 system.runInterval(() => {
     const debugMode = world.getDynamicProperty('debug_mode');
     const addonToggle = world.getDynamicProperty('addon_toggle');
+    const saturationHealing = world.getDynamicProperty('saturationHealing');
     const currentTick = system.currentTick;
 
     for (const player of world.getAllPlayers()) {
@@ -401,7 +421,10 @@ system.runInterval(() => {
             player.setSaturation(clampNumber(saturation + ((saturationEffect.amplifier + 1) * 2), saturationComp?.effectiveMin, saturationComp?.effectiveMax));
         }
 
+        if (saturationHealing && world.gameRules.naturalRegeneration == true) world.gameRules.naturalRegeneration = false;
+
         const canHeal =
+            saturationHealing &&
             hunger >= 18 &&
             health.currentValue > 0 &&
             health.currentValue < health.effectiveMax &&

--- a/packs/data/gametests/src/main/mathAndCalculations.ts
+++ b/packs/data/gametests/src/main/mathAndCalculations.ts
@@ -68,6 +68,7 @@ function initializePlayerStatus(player) {
         cooldown: 0,
         lastAttackTime: 0,
         lastShieldTime: 0,
+        foodTickTimer: 0,
         fallDistance: 0,
     };
     playerStatus.set(player, status);
@@ -382,6 +383,30 @@ Entity.prototype.getItemStats = function () {
 Entity.prototype.isTamed = function ({ excludeTypes = [] } = {}) {
     if (excludeTypes.includes(this.typeId)) return false;
     return this.getComponent('is_tamed')?.isValid;
+};
+
+Player.prototype.getHunger = function() {
+	return this.getComponent("player.hunger")?.currentValue;
+};
+
+Player.prototype.setHunger = function(number) {
+	this.getComponent("player.hunger")?.setCurrentValue(number);
+};
+
+Player.prototype.getSaturation = function() {
+	return this.getComponent("player.saturation")?.currentValue;
+};
+
+Player.prototype.setSaturation = function(number) {
+	this.getComponent("player.saturation")?.setCurrentValue(number);
+};
+
+Player.prototype.getExhaustion = function() {
+	return this.getComponent("player.exhaustion")?.currentValue;
+};
+
+Player.prototype.setExhaustion = function(number) {
+	this.getComponent("player.exhaustion")?.setCurrentValue(number);
 };
 
 // Script by JaylyMC


### PR DESCRIPTION
1.21.90 added writable hunger components, which allows me to directly modify hunger, saturation and exhaustion.

The way how saturation healing works is actually complicated. When a player has saturation more than 0 and has full hunger, the exhaustion will increase for 6 per half a heart (1 health) every 10 food ticks.

But the amount of exhaustion increase is actually based on saturation value, clamped to 6.
Say, if the player has saturation value of 5, the exhaustion will increase for 5 and the health will heal by 5/6.

This PR fully implements that.

One downside is that it requires natural regeneration off to function properly.